### PR TITLE
Rename "Delay" title to "Autoclose Delay"

### DIFF
--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -77,7 +77,7 @@ export const Options: React.FC<OptionsProps> = ({
       <h3>Options</h3>
       <div>
         <label htmlFor="autoClose">
-          Delay
+          Autoclose Delay
           <input
             type="number"
             name="autoClose"


### PR DESCRIPTION
This title is confusing, it says "delay" but modifies the props "autoclose" not "delay